### PR TITLE
Harden backend auth and add email OTP delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+.logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # Local SQLite database files
 data/
+
+# Local runtime toolchain
+.tools/

--- a/App.tsx
+++ b/App.tsx
@@ -232,25 +232,33 @@ const App: React.FC = () => {
     institution: string,
     password?: string
   }) => {
-    const otpHint = authService.sendOtp(details.email);
+    const otpHint = authService.sendSignupOtp(details.email);
     setAuthInfo({ flow: 'signup', ...details, otpHint });
     setView('verifyOtp');
   }, [setView]);
 
   const handleStartForgotPassword = useCallback(async (email: string): Promise<boolean> => {
-    const userExists = await authService.findUserByEmail(email);
-    if (userExists) {
-      const otpHint = authService.sendOtp(email);
-      setAuthInfo({ flow: 'forgotPassword', email, otpHint });
-      setView('verifyOtp');
-      return true;
-    }
-    return false;
+    const otpHint = await authService.requestPasswordReset(email);
+    setAuthInfo({ flow: 'forgotPassword', email, otpHint });
+    setView('verifyOtp');
+    return true;
   }, [setView]);
+
+  const handleVerifyOtpCode = useCallback(
+    async (otp: string): Promise<boolean> => {
+      if (!authInfo) return false;
+      if (authInfo.flow === 'signup') {
+        return authService.verifySignupOtp(authInfo.email, otp);
+      }
+      return authService.verifyPasswordResetOtp(authInfo.email, otp);
+    },
+    [authInfo]
+  );
 
   const handleResetPassword = useCallback(async (password: string): Promise<void> => {
     if (authInfo?.flow === 'forgotPassword') {
-      await authService.updatePassword(authInfo.email, password);
+      await authService.updatePassword(password);
+      authService.clearPendingPasswordReset();
       setAuthInfo(null);
       setView('login');
     }
@@ -278,8 +286,8 @@ const App: React.FC = () => {
           unlockedAchievements: [],
         };
         await authService.createUser(newUser);
-        await authService.createSession(newUser);
-        setCurrentUser(newUser);
+        const sessionUser = await authService.checkSession();
+        setCurrentUser(sessionUser || { ...newUser, password: undefined });
         setView('home');
         setAuthInfo(null);
       } else {
@@ -356,7 +364,14 @@ const App: React.FC = () => {
         return <Login onLogin={handleLogin} setView={setView} />;
       case 'verifyOtp':
         if (authInfo) {
-          return <VerifyOtp authInfo={authInfo} onVerified={handleOtpVerified} otpHint={authInfo.otpHint} />;
+          return (
+            <VerifyOtp
+              authInfo={authInfo}
+              verifyCode={handleVerifyOtpCode}
+              onVerified={handleOtpVerified}
+              otpHint={authInfo.otpHint}
+            />
+          );
         }
         return <Login onLogin={handleLogin} setView={setView} />;
       default:

--- a/App.tsx
+++ b/App.tsx
@@ -224,24 +224,33 @@ const App: React.FC = () => {
     return false;
   }, [setView]);
 
-  const handleStartSignup = useCallback((details: {
+  const handleStartSignup = useCallback(async (details: {
     name: string,
     email: string,
     phone?: string,
     role: UserRole,
     institution: string,
     password?: string
-  }) => {
-    const otpHint = authService.sendSignupOtp(details.email);
-    setAuthInfo({ flow: 'signup', ...details, otpHint });
-    setView('verifyOtp');
+  }): Promise<boolean> => {
+    try {
+      const otpHint = await authService.requestSignupOtp(details.email);
+      setAuthInfo({ flow: 'signup', ...details, otpHint });
+      setView('verifyOtp');
+      return true;
+    } catch {
+      return false;
+    }
   }, [setView]);
 
   const handleStartForgotPassword = useCallback(async (email: string): Promise<boolean> => {
-    const otpHint = await authService.requestPasswordReset(email);
-    setAuthInfo({ flow: 'forgotPassword', email, otpHint });
-    setView('verifyOtp');
-    return true;
+    try {
+      const otpHint = await authService.requestPasswordReset(email);
+      setAuthInfo({ flow: 'forgotPassword', email, otpHint });
+      setView('verifyOtp');
+      return true;
+    } catch {
+      return false;
+    }
   }, [setView]);
 
   const handleVerifyOtpCode = useCallback(
@@ -285,7 +294,12 @@ const App: React.FC = () => {
           streak: { count: 0, lastActivityDate: null },
           unlockedAchievements: [],
         };
-        await authService.createUser(newUser);
+        const created = await authService.createUser(newUser);
+        if (!created) {
+          setView('signup');
+          setAuthInfo(null);
+          return;
+        }
         const sessionUser = await authService.checkSession();
         setCurrentUser(sessionUser || { ...newUser, password: undefined });
         setView('home');

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ This project now includes:
    ```env
    GEMINI_API_KEY=your_api_key_here
    JWT_SECRET=your_strong_random_secret_here
+   # Required to send OTPs by email
+   SMTP_HOST=smtp.yourprovider.com
+   SMTP_PORT=587
+   SMTP_SECURE=false
+   SMTP_USER=your_smtp_username
+   SMTP_PASS=your_smtp_password
+   SMTP_FROM="CrisisGuardian <no-reply@yourdomain.com>"
    ```
 
 3. Start frontend + API together:
@@ -47,7 +54,16 @@ This project now includes:
 
 - Authentication is handled server-side with HTTP-only signed session cookies.
 - Passwords are hashed (`bcrypt`) before storage.
+- Signup and password-reset OTPs are generated and verified server-side.
+- OTP emails are sent via SMTP when `SMTP_*` variables are configured.
 - AI calls are proxied through backend `/api/ai/*` routes so API keys are not exposed in the client bundle.
+
+## OTP Delivery Notes
+
+- Production: OTP codes are delivered only by email.
+- Local development:
+  - If SMTP is configured, OTP is sent to the email inbox.
+  - If SMTP is not configured, OTP is returned as `otpHint` in the API response for testing.
 
 ## Database Notes
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ This project now includes:
    npm install
    ```
 
-2. Set your Gemini key in `.env.local`:
+2. Set your backend env vars in `.env.local`:
    ```env
    GEMINI_API_KEY=your_api_key_here
+   JWT_SECRET=your_strong_random_secret_here
    ```
 
 3. Start frontend + API together:
@@ -41,6 +42,12 @@ This project now includes:
 - `npm run dev:full` - frontend + API together
 - `npm run build` - production frontend build
 - `npm run start:api` - start API without watch mode
+
+## Security Notes
+
+- Authentication is handled server-side with HTTP-only signed session cookies.
+- Passwords are hashed (`bcrypt`) before storage.
+- AI calls are proxied through backend `/api/ai/*` routes so API keys are not exposed in the client bundle.
 
 ## Database Notes
 

--- a/README.md
+++ b/README.md
@@ -82,16 +82,22 @@ This app can be deployed as a single Node service:
 ### Render (recommended)
 
 1. Push this repo to GitHub.
-2. In Render, create a **Web Service** from the repo.
-3. Set:
-   - Runtime: `Node`
-   - Build Command: `npm install && npm run build`
-   - Start Command: `npm start`
-4. Add environment variable:
+2. In Render, create a **Blueprint** from the repo (uses `render.yaml` in this project).
+3. Set these environment variables in Render:
    - `GEMINI_API_KEY=your_key`
-5. Add a **Persistent Disk** (important for SQLite persistence):
-   - Mount path: `/opt/render/project/src/data`
-6. Deploy.
+   - `SMTP_HOST=...`
+   - `SMTP_PORT=587`
+   - `SMTP_SECURE=false`
+   - `SMTP_USER=...`
+   - `SMTP_PASS=...`
+   - `SMTP_FROM=CrisisGuardian <no-reply@yourdomain.com>`
+4. Deploy.
+
+Notes:
+- On Render free tier, filesystem is ephemeral and SQLite data can reset on restarts/redeploys.
+- For persistence, upgrade plan and attach a disk mounted at `/opt/render/project/src/data`.
+- `FRONTEND_ORIGIN` is optional on Render because backend falls back to `RENDER_EXTERNAL_URL`.
+- If you do set `FRONTEND_ORIGIN`, use your exact Render app URL (for example, `https://your-app.onrender.com`).
 
 After deploy:
 - App URL: `https://<your-service>.onrender.com`

--- a/components/Signup.tsx
+++ b/components/Signup.tsx
@@ -11,7 +11,7 @@ interface SignupProps {
       role: UserRole,
       institution: string,
       password?: string
-    }) => void;
+    }) => Promise<boolean>;
   setView: (view: View) => void;
 }
 
@@ -133,13 +133,19 @@ const Signup: React.FC<SignupProps> = ({ onStartSignup, setView }) => {
         return;
     }
 
-    onStartSignup({
+    const started = await onStartSignup({
       name,
       email,
       role: selectedRole,
       institution: finalInstitution,
       password
     });
+
+    if (!started) {
+      setError('Could not send verification code right now. Please try again.');
+      setIsLoading(false);
+      return;
+    }
   };
 
   return (

--- a/components/VerifyOtp.tsx
+++ b/components/VerifyOtp.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { CrisisGuardianLogo } from './icons/Icons';
-import * as authService from '../services/authService';
 
 type AuthInfo = {
   flow: 'signup' | 'forgotPassword';
@@ -9,11 +8,12 @@ type AuthInfo = {
 
 interface VerifyOtpProps {
   authInfo: AuthInfo;
+  verifyCode: (code: string) => Promise<boolean>;
   onVerified: (email: string) => void;
   otpHint?: string;
 }
 
-const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, onVerified, otpHint }) => {
+const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, verifyCode, onVerified, otpHint }) => {
   const [otp, setOtp] = useState<string[]>(new Array(6).fill(''));
   const [error, setError] = useState<string>('');
   const [showHint, setShowHint] = useState(true);
@@ -50,7 +50,7 @@ const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, onVerified, otpHint }) 
       }
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
     const enteredOtp = otp.join('');
@@ -60,7 +60,7 @@ const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, onVerified, otpHint }) 
       return;
     }
 
-    const isValid = authService.verifyOtp(authInfo.email, enteredOtp);
+    const isValid = await verifyCode(enteredOtp);
 
     if (isValid) {
       onVerified(authInfo.email);

--- a/components/VerifyOtp.tsx
+++ b/components/VerifyOtp.tsx
@@ -16,6 +16,7 @@ interface VerifyOtpProps {
 const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, verifyCode, onVerified, otpHint }) => {
   const [otp, setOtp] = useState<string[]>(new Array(6).fill(''));
   const [error, setError] = useState<string>('');
+  const [isVerifying, setIsVerifying] = useState(false);
   const [showHint, setShowHint] = useState(true);
   const inputsRef = useRef<(HTMLInputElement | null)[]>([]);
 
@@ -52,6 +53,7 @@ const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, verifyCode, onVerified,
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isVerifying) return;
     setError('');
     const enteredOtp = otp.join('');
 
@@ -60,7 +62,9 @@ const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, verifyCode, onVerified,
       return;
     }
 
+    setIsVerifying(true);
     const isValid = await verifyCode(enteredOtp);
+    setIsVerifying(false);
 
     if (isValid) {
       onVerified(authInfo.email);
@@ -107,6 +111,7 @@ const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, verifyCode, onVerified,
                   onChange={e => handleChange(e.target, index)}
                   onKeyDown={e => handleKeyDown(e, index)}
                   onFocus={e => e.target.select()}
+                  disabled={isVerifying}
                   ref={el => { if (el) { inputsRef.current[index] = el; } }}
                   className="w-12 h-14 text-center text-2xl font-semibold bg-purple-500/5 dark:bg-white/10 border-2 border-transparent focus:border-[--brand-purple] focus:ring-0 rounded-2xl transition-colors"
                 />
@@ -117,9 +122,10 @@ const VerifyOtp: React.FC<VerifyOtpProps> = ({ authInfo, verifyCode, onVerified,
 
             <button
               type="submit"
+              disabled={isVerifying}
               className="w-full mt-6 bg-[--brand-purple] text-white font-bold py-4 px-4 rounded-2xl hover:bg-purple-700 transition-all duration-300 transform hover:-translate-y-1"
             >
-              {buttonText}
+              {isVerifying ? 'Verifying...' : buttonText}
             </button>
           </form>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@google/genai": "^1.20.0",
         "bcryptjs": "^2.4.3",
-        "better-sqlite3": "^11.8.1",
+        "better-sqlite3": "^12.6.2",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -18,6 +18,7 @@
         "express-rate-limit": "^7.5.0",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^8.0.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "recharts": "^3.2.1"
@@ -1581,14 +1582,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bignumber.js": {
@@ -3440,6 +3444,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,15 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.20.0",
+        "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.8.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dotenv": "^16.6.1",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
+        "helmet": "^8.1.0",
+        "jsonwebtoken": "^9.0.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "recharts": "^3.2.1"
@@ -1568,6 +1574,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/better-sqlite3": {
       "version": "11.10.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
@@ -2017,6 +2029,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
@@ -2259,6 +2290,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2491,6 +2534,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -2855,6 +2913,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3032,6 +3099,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -3052,6 +3153,48 @@
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,15 @@
   },
   "dependencies": {
     "@google/genai": "^1.20.0",
+    "bcryptjs": "^2.4.3",
     "better-sqlite3": "^11.8.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "dotenv": "^16.6.1",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
+    "helmet": "^8.1.0",
+    "jsonwebtoken": "^9.0.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "recharts": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@google/genai": "^1.20.0",
     "bcryptjs": "^2.4.3",
-    "better-sqlite3": "^11.8.1",
+    "better-sqlite3": "^12.6.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
@@ -23,6 +23,7 @@
     "express-rate-limit": "^7.5.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^8.0.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "recharts": "^3.2.1"

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,30 @@
+services:
+  - type: web
+    name: crisisguardian
+    env: node
+    plan: free
+    buildCommand: npm install && npm run build
+    startCommand: npm start
+    healthCheckPath: /api/health
+    autoDeploy: true
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: JWT_SECRET
+        generateValue: true
+      - key: GEMINI_API_KEY
+        sync: false
+      - key: FRONTEND_ORIGIN
+        sync: false
+      - key: SMTP_HOST
+        sync: false
+      - key: SMTP_PORT
+        value: "587"
+      - key: SMTP_SECURE
+        value: "false"
+      - key: SMTP_USER
+        sync: false
+      - key: SMTP_PASS
+        sync: false
+      - key: SMTP_FROM
+        sync: false

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import cookieParser from 'cookie-parser';
+import nodemailer from 'nodemailer';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { GoogleGenAI, Type } from '@google/genai';
@@ -29,6 +30,12 @@ const SIGNUP_OTP_TTL_MS = 1000 * 60 * 5;
 const PASSWORD_RESET_OTP_TTL_MS = 1000 * 60 * 5;
 const OTP_MAX_ATTEMPTS = 5;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const SMTP_HOST = process.env.SMTP_HOST;
+const SMTP_PORT = Number(process.env.SMTP_PORT || 0);
+const SMTP_USER = process.env.SMTP_USER;
+const SMTP_PASS = process.env.SMTP_PASS;
+const SMTP_SECURE = String(process.env.SMTP_SECURE || 'false').toLowerCase() === 'true';
+const SMTP_FROM = process.env.SMTP_FROM;
 const DB_DIR = path.resolve(process.cwd(), 'data');
 const DB_PATH = path.join(DB_DIR, 'crisisguardian.db');
 const DIST_PATH = path.resolve(process.cwd(), 'dist');
@@ -101,6 +108,9 @@ if (!IS_PROD && process.env.JWT_SECRET == null) {
 if (!IS_PROD && !GEMINI_API_KEY) {
   console.warn('[CrisisGuardian API] GEMINI_API_KEY is not configured. AI endpoints will be unavailable.');
 }
+if (!SMTP_HOST || !SMTP_PORT || !SMTP_USER || !SMTP_PASS || !SMTP_FROM) {
+  console.warn('[CrisisGuardian API] SMTP config is incomplete. OTP emails will not be sent.');
+}
 
 const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
 
@@ -155,7 +165,24 @@ const OTP_TABLES = {
   passwordReset: 'password_reset_codes'
 };
 
+const OTP_PURPOSE_TITLES = {
+  signup: 'Sign-Up Verification',
+  passwordReset: 'Password Reset'
+};
+
 const getOtpTableName = (purpose) => OTP_TABLES[purpose];
+const otpEmailEnabled = Boolean(SMTP_HOST && SMTP_PORT && SMTP_USER && SMTP_PASS && SMTP_FROM);
+const mailTransporter = otpEmailEnabled
+  ? nodemailer.createTransport({
+      host: SMTP_HOST,
+      port: SMTP_PORT,
+      secure: SMTP_SECURE,
+      auth: {
+        user: SMTP_USER,
+        pass: SMTP_PASS
+      }
+    })
+  : null;
 
 const issueOtpCode = ({ purpose, email, ttlMs }) => {
   const table = getOtpTableName(purpose);
@@ -216,6 +243,41 @@ const verifyAndConsumeOtpCode = ({ purpose, email, otp }) => {
 
   db.prepare(`DELETE FROM ${table} WHERE email = ?`).run(email);
   return true;
+};
+
+const sendOtpEmail = async ({ purpose, email, otp, ttlMs }) => {
+  if (!mailTransporter || !otpEmailEnabled) {
+    throw new Error('OTP email service is not configured.');
+  }
+
+  const purposeTitle = OTP_PURPOSE_TITLES[purpose] || 'Verification';
+  const ttlMinutes = Math.max(1, Math.round(ttlMs / 60000));
+  const subject = `CrisisGuardian ${purposeTitle} Code`;
+
+  const text = [
+    `Your CrisisGuardian ${purposeTitle.toLowerCase()} code is: ${otp}`,
+    `This code expires in ${ttlMinutes} minute(s).`,
+    '',
+    'If you did not request this code, you can ignore this email.'
+  ].join('\n');
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #111827;">
+      <h2 style="margin: 0 0 12px;">CrisisGuardian ${purposeTitle}</h2>
+      <p>Your verification code is:</p>
+      <p style="font-size: 28px; font-weight: 700; letter-spacing: 4px; margin: 12px 0;">${otp}</p>
+      <p>This code expires in <strong>${ttlMinutes} minute(s)</strong>.</p>
+      <p style="font-size: 13px; color: #6b7280;">If you did not request this code, you can ignore this email.</p>
+    </div>
+  `;
+
+  await mailTransporter.sendMail({
+    from: SMTP_FROM,
+    to: email,
+    subject,
+    text,
+    html
+  });
 };
 
 const parseRowPayload = (row) => {
@@ -557,7 +619,7 @@ app.post('/api/auth/check-email', authLimiter, (req, res) => {
   return res.json({ exists });
 });
 
-app.post('/api/auth/request-signup-otp', authLimiter, (req, res) => {
+app.post('/api/auth/request-signup-otp', authLimiter, async (req, res) => {
   const email = normalizeEmail(req.body?.email);
   if (!email || !isValidEmail(email)) {
     return res.status(400).json({ error: 'Valid email is required.' });
@@ -565,8 +627,26 @@ app.post('/api/auth/request-signup-otp', authLimiter, (req, res) => {
   if (getUserRecord(email)) {
     return res.status(409).json({ error: 'An account with this email already exists.' });
   }
+  if (IS_PROD && !otpEmailEnabled) {
+    return res.status(503).json({ error: 'OTP email service is not configured.' });
+  }
 
   const otp = issueOtpCode({ purpose: 'signup', email, ttlMs: SIGNUP_OTP_TTL_MS });
+  try {
+    if (otpEmailEnabled) {
+      await sendOtpEmail({
+        purpose: 'signup',
+        email,
+        otp,
+        ttlMs: SIGNUP_OTP_TTL_MS
+      });
+    }
+  } catch (error) {
+    console.error('Failed to send signup OTP email:', error);
+    db.prepare('DELETE FROM signup_verification_codes WHERE email = ?').run(email);
+    return res.status(502).json({ error: 'Failed to deliver verification code email.' });
+  }
+
   if (!IS_PROD) {
     return res.json({ ok: true, otpHint: otp });
   }
@@ -686,15 +766,31 @@ app.post('/api/auth/logout', (_req, res) => {
   return res.json({ ok: true });
 });
 
-app.post('/api/auth/request-password-reset', authLimiter, (req, res) => {
+app.post('/api/auth/request-password-reset', authLimiter, async (req, res) => {
   const email = normalizeEmail(req.body?.email);
   if (!email || !isValidEmail(email)) {
     return res.status(400).json({ error: 'Valid email is required.' });
+  }
+  if (IS_PROD && !otpEmailEnabled) {
+    return res.status(503).json({ error: 'OTP email service is not configured.' });
   }
 
   const userRecord = getUserRecord(email);
   if (userRecord) {
     const otp = issueOtpCode({ purpose: 'passwordReset', email, ttlMs: PASSWORD_RESET_OTP_TTL_MS });
+    if (otpEmailEnabled) {
+      try {
+        await sendOtpEmail({
+          purpose: 'passwordReset',
+          email,
+          otp,
+          ttlMs: PASSWORD_RESET_OTP_TTL_MS
+        });
+      } catch (error) {
+        // Keep response generic to avoid account enumeration.
+        console.error('Failed to send password reset OTP email:', error);
+      }
+    }
 
     if (!IS_PROD) {
       return res.json({ ok: true, otpHint: otp });

--- a/server/index.js
+++ b/server/index.js
@@ -1,11 +1,31 @@
 import fs from 'fs';
 import path from 'path';
+import crypto from 'crypto';
+import dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import cookieParser from 'cookie-parser';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { GoogleGenAI, Type } from '@google/genai';
 import Database from 'better-sqlite3';
 
+dotenv.config({ path: '.env.local' });
+dotenv.config();
+
 const app = express();
+const NODE_ENV = process.env.NODE_ENV || 'development';
+const IS_PROD = NODE_ENV === 'production';
 const PORT = Number(process.env.PORT || process.env.API_PORT || 3001);
+const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN;
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-change-this-jwt-secret';
+const RESET_TOKEN_SECRET = process.env.RESET_TOKEN_SECRET || `${JWT_SECRET}-reset`;
+const SESSION_COOKIE_NAME = 'cg_session';
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7;
+const PASSWORD_RESET_OTP_TTL_MS = 1000 * 60 * 5;
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const DB_DIR = path.resolve(process.cwd(), 'data');
 const DB_PATH = path.join(DB_DIR, 'crisisguardian.db');
 const DIST_PATH = path.resolve(process.cwd(), 'dist');
@@ -22,6 +42,7 @@ db.exec(`
 CREATE TABLE IF NOT EXISTS users (
   email TEXT PRIMARY KEY,
   payload TEXT NOT NULL,
+  password_hash TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
@@ -45,7 +66,31 @@ CREATE TABLE IF NOT EXISTS sessions (
   updated_at TEXT NOT NULL,
   FOREIGN KEY(email) REFERENCES users(email)
 );
+
+CREATE TABLE IF NOT EXISTS password_reset_codes (
+  email TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY(email) REFERENCES users(email)
+);
 `);
+
+const userColumns = db.prepare('PRAGMA table_info(users)').all();
+if (!userColumns.some((column) => column.name === 'password_hash')) {
+  db.exec('ALTER TABLE users ADD COLUMN password_hash TEXT');
+}
+
+if (!IS_PROD && process.env.JWT_SECRET == null) {
+  console.warn('[CrisisGuardian API] JWT_SECRET is not set. Using a development fallback secret.');
+}
+if (!IS_PROD && !GEMINI_API_KEY) {
+  console.warn('[CrisisGuardian API] GEMINI_API_KEY is not configured. AI endpoints will be unavailable.');
+}
+
+const ai = GEMINI_API_KEY ? new GoogleGenAI({ apiKey: GEMINI_API_KEY }) : null;
 
 const INDIAN_SCHOOLS = [
   'Delhi Public School, R.K. Puram',
@@ -81,21 +126,48 @@ const defaultAnalytics = () => ({
   scoresByType: {}
 });
 
-const nowIso = () => new Date().toISOString();
+const VALID_ROLES = new Set(['Student', 'Teacher', 'Admin']);
+const VALID_INSTITUTION_TYPES = new Set(['school', 'college']);
+const VALID_DISASTER_TYPES = new Set(['Earthquake', 'Flood', 'Fire', 'Cyclone']);
+const VALID_DRILL_MODES = new Set(['Standard', 'Survival']);
+const VALID_VIDEO_STYLES = new Set(['cartoon', 'realistic']);
 
-const parseRowPayload = (row) => (row ? JSON.parse(row.payload) : null);
+const nowIso = () => new Date().toISOString();
+const normalizeEmail = (email) => String(email || '').trim().toLowerCase();
+const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+const hashPassword = (password) => bcrypt.hashSync(password, 12);
+const verifyPassword = (password, hash) => bcrypt.compareSync(password, hash);
+const hashOtp = (otp) => crypto.createHash('sha256').update(String(otp)).digest('hex');
+
+const parseRowPayload = (row) => {
+  if (!row) return null;
+  try {
+    return JSON.parse(row.payload);
+  } catch {
+    return null;
+  }
+};
 const isFiniteNumber = (value) => typeof value === 'number' && Number.isFinite(value);
 const levelFromXp = (xp) => Math.max(1, Math.floor(Math.sqrt(xp / 100)) + 1);
 
 const normalizeUser = (user) => {
-  if (!user || typeof user !== 'object') return user;
+  if (!user || typeof user !== 'object') return null;
+
+  const email = normalizeEmail(user.email);
+  if (!email) return null;
 
   const normalizedXp = isFiniteNumber(user.xp) ? Math.max(0, Math.round(user.xp)) : 0;
   const normalizedLevel = isFiniteNumber(user.level) ? Math.max(1, Math.round(user.level)) : levelFromXp(normalizedXp);
+  const role = VALID_ROLES.has(user.role) ? user.role : 'Student';
 
   return {
-    ...user,
+    name: typeof user.name === 'string' ? user.name.trim() : '',
+    email,
+    phone: typeof user.phone === 'string' && user.phone.trim() ? user.phone.trim() : undefined,
+    role,
+    institution: typeof user.institution === 'string' ? user.institution.trim() : '',
     score: isFiniteNumber(user.score) ? Math.round(user.score) : 0,
+    avatar: typeof user.avatar === 'string' && user.avatar.trim() ? user.avatar : 'avatar1',
     drillHistory: Array.isArray(user.drillHistory) ? user.drillHistory : [],
     xp: normalizedXp,
     level: normalizedLevel,
@@ -106,6 +178,111 @@ const normalizeUser = (user) => {
     },
     unlockedAchievements: Array.isArray(user.unlockedAchievements) ? user.unlockedAchievements : [],
   };
+};
+
+const getUserRecord = (email) => {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) return null;
+  const row = db
+    .prepare('SELECT email, payload, password_hash, created_at, updated_at FROM users WHERE email = ?')
+    .get(normalizedEmail);
+  if (!row) return null;
+  const parsed = parseRowPayload(row);
+  const normalized = normalizeUser({ ...parsed, email: normalizedEmail });
+  if (!normalized) return null;
+  return {
+    email: normalizedEmail,
+    user: normalized,
+    passwordHash: row.password_hash,
+    createdAt: row.created_at,
+  };
+};
+
+const upsertUser = ({ email, user, passwordHash, createdAt }) => {
+  const normalizedEmail = normalizeEmail(email);
+  const normalizedUser = normalizeUser({ ...user, email: normalizedEmail });
+  if (!normalizedUser) throw new Error('Invalid user payload.');
+  if (!passwordHash) throw new Error('Password hash is required.');
+
+  const stamp = nowIso();
+  db.prepare(`
+    INSERT INTO users(email, payload, password_hash, created_at, updated_at)
+    VALUES(@email, @payload, @passwordHash, @createdAt, @updatedAt)
+    ON CONFLICT(email) DO UPDATE SET
+      payload = excluded.payload,
+      password_hash = excluded.password_hash,
+      updated_at = excluded.updated_at
+  `).run({
+    email: normalizedEmail,
+    payload: JSON.stringify(normalizedUser),
+    passwordHash,
+    createdAt: createdAt || stamp,
+    updatedAt: stamp
+  });
+  return normalizedUser;
+};
+
+const signSessionToken = (user) =>
+  jwt.sign({ sub: user.email, role: user.role }, JWT_SECRET, { expiresIn: '7d' });
+
+const readSessionTokenFromRequest = (req) => {
+  const authHeader = req.headers.authorization;
+  if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+    return authHeader.slice('Bearer '.length);
+  }
+  return req.cookies?.[SESSION_COOKIE_NAME] || null;
+};
+
+const setSessionCookie = (res, token) => {
+  res.cookie(SESSION_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: IS_PROD,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SESSION_TTL_MS
+  });
+};
+
+const clearSessionCookie = (res) => {
+  res.clearCookie(SESSION_COOKIE_NAME, {
+    httpOnly: true,
+    secure: IS_PROD,
+    sameSite: 'lax',
+    path: '/'
+  });
+};
+
+const getAuthFromRequest = (req) => {
+  const token = readSessionTokenFromRequest(req);
+  if (!token) return null;
+
+  let decoded;
+  try {
+    decoded = jwt.verify(token, JWT_SECRET);
+  } catch {
+    return null;
+  }
+
+  const email = normalizeEmail(decoded?.sub);
+  if (!email) return null;
+
+  return getUserRecord(email);
+};
+
+const requireAuth = (req, res, next) => {
+  const auth = getAuthFromRequest(req);
+  if (!auth) {
+    return res.status(401).json({ error: 'Authentication required.' });
+  }
+  req.auth = auth;
+  return next();
+};
+
+const requireAdmin = (req, res, next) => {
+  if (!req.auth || req.auth.user.role !== 'Admin') {
+    return res.status(403).json({ error: 'Admin access required.' });
+  }
+  return next();
 };
 
 const seedInstitutions = () => {
@@ -119,8 +296,7 @@ const seedInstitutions = () => {
 
 const makeSeedUser = ({ name, email, role, institution, score, avatar, xp, level, trophies, streak }) => ({
   name,
-  email,
-  password: 'password',
+  email: normalizeEmail(email),
   role,
   institution,
   score,
@@ -161,22 +337,14 @@ const seedUsers = () => {
     })
   ];
 
-  const upsert = db.prepare(`
-    INSERT INTO users(email, payload, created_at, updated_at)
-    VALUES(@email, @payload, @createdAt, @updatedAt)
-    ON CONFLICT(email) DO UPDATE SET
-      payload = excluded.payload,
-      updated_at = excluded.updated_at
-  `);
-
   const tx = db.transaction(() => {
     users.forEach((user) => {
-      const stamp = nowIso();
-      upsert.run({
-        email: user.email.toLowerCase(),
-        payload: JSON.stringify({ ...user, email: user.email.toLowerCase() }),
-        createdAt: stamp,
-        updatedAt: stamp
+      const existing = getUserRecord(user.email);
+      upsertUser({
+        email: user.email,
+        user,
+        passwordHash: existing?.passwordHash || hashPassword('password'),
+        createdAt: existing?.createdAt
       });
     });
   });
@@ -202,17 +370,21 @@ const ensureSeedData = () => {
 };
 
 const migrateUsers = () => {
-  const rows = db.prepare('SELECT email, payload FROM users').all();
+  const rows = db.prepare('SELECT email, payload, password_hash FROM users').all();
   if (!rows.length) return;
 
-  const updateStmt = db.prepare('UPDATE users SET payload = ?, updated_at = ? WHERE email = ?');
+  const updateStmt = db.prepare('UPDATE users SET payload = ?, password_hash = ?, updated_at = ? WHERE email = ?');
   const tx = db.transaction(() => {
     rows.forEach((row) => {
-      const user = JSON.parse(row.payload);
-      const normalized = normalizeUser(user);
-      if (JSON.stringify(user) !== JSON.stringify(normalized)) {
-        updateStmt.run(JSON.stringify(normalized), nowIso(), row.email);
-      }
+      const user = parseRowPayload(row);
+      if (!user) return;
+      const legacyPassword =
+        typeof user.password === 'string' && user.password.length >= 6 ? user.password : null;
+      const { password, ...strippedUser } = user;
+      const normalized = normalizeUser({ ...strippedUser, email: row.email });
+      if (!normalized) return;
+      const nextPasswordHash = row.password_hash || hashPassword(legacyPassword || 'password');
+      updateStmt.run(JSON.stringify(normalized), nextPasswordHash, nowIso(), normalizeEmail(row.email));
     });
   });
   tx();
@@ -221,16 +393,54 @@ const migrateUsers = () => {
 ensureSeedData();
 migrateUsers();
 
-app.use(cors());
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 40,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+const aiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+const allowedOrigins = new Set(
+  [FRONTEND_ORIGIN, 'http://localhost:3000', 'http://127.0.0.1:3000'].filter(Boolean)
+);
+
+app.set('trust proxy', 1);
+app.use(
+  helmet({
+    crossOriginResourcePolicy: false
+  })
+);
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.has(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Origin not allowed by CORS.'));
+    },
+    credentials: true
+  })
+);
+app.use(cookieParser());
 app.use(express.json({ limit: '1mb' }));
 
 app.get('/api/health', (_req, res) => {
-  res.json({ ok: true, dbPath: DB_PATH });
+  res.json({ ok: true, dbPath: DB_PATH, env: NODE_ENV });
 });
 
 app.post('/api/seed', (_req, res) => {
+  if (IS_PROD) {
+    return res.status(403).json({ error: 'Seeding is disabled in production.' });
+  }
   ensureSeedData();
-  res.json({ ok: true });
+  return res.json({ ok: true });
 });
 
 app.get('/api/institutions', (_req, res) => {
@@ -239,12 +449,12 @@ app.get('/api/institutions', (_req, res) => {
   res.json({ schools, colleges });
 });
 
-app.post('/api/institutions', (req, res) => {
+app.post('/api/institutions', requireAuth, requireAdmin, (req, res) => {
   const { name, type } = req.body || {};
   if (!name || typeof name !== 'string' || !name.trim()) {
     return res.status(400).json({ error: 'Name is required.' });
   }
-  if (type !== 'school' && type !== 'college') {
+  if (!VALID_INSTITUTION_TYPES.has(type)) {
     return res.status(400).json({ error: 'Type must be school or college.' });
   }
 
@@ -259,138 +469,334 @@ app.post('/api/institutions', (req, res) => {
   }
 });
 
-app.get('/api/users', (_req, res) => {
-  const rows = db.prepare('SELECT payload FROM users').all();
-  res.json(rows.map(parseRowPayload).map(normalizeUser));
+app.post('/api/auth/check-email', authLimiter, (req, res) => {
+  const email = normalizeEmail(req.body?.email);
+  if (!email || !isValidEmail(email)) {
+    return res.status(400).json({ error: 'Valid email is required.' });
+  }
+  const exists = Boolean(db.prepare('SELECT 1 FROM users WHERE email = ?').get(email));
+  return res.json({ exists });
 });
 
-app.get('/api/users/:email', (req, res) => {
-  const email = String(req.params.email || '').toLowerCase();
-  const row = db.prepare('SELECT payload FROM users WHERE email = ?').get(email);
-  res.json(normalizeUser(parseRowPayload(row)));
-});
+app.post('/api/auth/signup', authLimiter, (req, res) => {
+  const { name, email, password, role, institution, phone, avatar } = req.body || {};
+  const normalizedEmail = normalizeEmail(email);
 
-app.post('/api/users', (req, res) => {
-  const user = req.body;
-  if (!user || !user.email) {
-    return res.status(400).json({ error: 'User payload with email is required.' });
+  if (!normalizedEmail || !isValidEmail(normalizedEmail)) {
+    return res.status(400).json({ error: 'Valid email is required.' });
+  }
+  if (typeof password !== 'string' || password.length < 6) {
+    return res.status(400).json({ error: 'Password must be at least 6 characters.' });
+  }
+  if (typeof name !== 'string' || name.trim().length < 3) {
+    return res.status(400).json({ error: 'Name must be at least 3 characters.' });
+  }
+  if (!VALID_ROLES.has(role)) {
+    return res.status(400).json({ error: 'Role is invalid.' });
+  }
+  if (typeof institution !== 'string' || !institution.trim()) {
+    return res.status(400).json({ error: 'Institution is required.' });
   }
 
-  const email = String(user.email).toLowerCase();
-  const existing = db.prepare('SELECT email FROM users WHERE email = ?').get(email);
-  if (existing) {
+  if (getUserRecord(normalizedEmail)) {
     return res.status(409).json({ error: 'User already exists.' });
   }
 
-  const stamp = nowIso();
-  const canonicalUser = normalizeUser({ ...user, email, trophies: user.trophies ?? 0 });
-  db.prepare('INSERT INTO users(email, payload, created_at, updated_at) VALUES (?, ?, ?, ?)').run(
-    email,
-    JSON.stringify(canonicalUser),
-    stamp,
-    stamp
-  );
-
-  return res.status(201).json({ ok: true });
-});
-
-app.put('/api/users/:email', (req, res) => {
-  const email = String(req.params.email || '').toLowerCase();
-  const user = req.body;
-  if (!user) {
-    return res.status(400).json({ error: 'User payload is required.' });
-  }
-
-  const stamp = nowIso();
-  const canonicalUser = normalizeUser({ ...user, email });
-  db.prepare(`
-    INSERT INTO users(email, payload, created_at, updated_at)
-    VALUES(@email, @payload, @createdAt, @updatedAt)
-    ON CONFLICT(email) DO UPDATE SET
-      payload = excluded.payload,
-      updated_at = excluded.updated_at
-  `).run({
-    email,
-    payload: JSON.stringify(canonicalUser),
-    createdAt: stamp,
-    updatedAt: stamp
+  const user = normalizeUser({
+    name: name.trim(),
+    email: normalizedEmail,
+    phone: typeof phone === 'string' ? phone.trim() : undefined,
+    role,
+    institution: institution.trim(),
+    avatar: typeof avatar === 'string' && avatar.trim() ? avatar : 'avatar1',
+    score: 0,
+    drillHistory: [],
+    xp: 0,
+    level: 1,
+    trophies: 0,
+    streak: { count: 0, lastActivityDate: null },
+    unlockedAchievements: []
   });
 
+  const savedUser = upsertUser({
+    email: normalizedEmail,
+    user,
+    passwordHash: hashPassword(password)
+  });
+  setSessionCookie(res, signSessionToken(savedUser));
+  return res.status(201).json({ user: savedUser });
+});
+
+app.post('/api/auth/login', authLimiter, (req, res) => {
+  const email = normalizeEmail(req.body?.email);
+  const password = req.body?.password;
+
+  if (!email || !isValidEmail(email) || typeof password !== 'string' || !password) {
+    return res.status(400).json({ error: 'Email and password are required.' });
+  }
+
+  const record = getUserRecord(email);
+  if (!record || !record.passwordHash || !verifyPassword(password, record.passwordHash)) {
+    return res.status(401).json({ error: 'Invalid credentials.' });
+  }
+
+  setSessionCookie(res, signSessionToken(record.user));
+  return res.json({ user: record.user });
+});
+
+app.get('/api/auth/me', requireAuth, (req, res) => {
+  return res.json({ user: req.auth.user });
+});
+
+app.post('/api/auth/logout', (_req, res) => {
+  clearSessionCookie(res);
   return res.json({ ok: true });
 });
 
-app.patch('/api/users/:email/password', (req, res) => {
-  const email = String(req.params.email || '').toLowerCase();
-  const { password } = req.body || {};
-  if (!password || typeof password !== 'string') {
-    return res.status(400).json({ error: 'Password is required.' });
+app.post('/api/auth/request-password-reset', authLimiter, (req, res) => {
+  const email = normalizeEmail(req.body?.email);
+  if (!email || !isValidEmail(email)) {
+    return res.status(400).json({ error: 'Valid email is required.' });
   }
 
-  const row = db.prepare('SELECT payload FROM users WHERE email = ?').get(email);
-  if (!row) {
-    return res.status(404).json({ error: 'User not found.' });
-  }
-
-  const user = normalizeUser(parseRowPayload(row));
-  user.password = password;
-
-  db.prepare('UPDATE users SET payload = ?, updated_at = ? WHERE email = ?').run(JSON.stringify(user), nowIso(), email);
-  return res.json({ ok: true });
-});
-
-app.get('/api/session', (_req, res) => {
-  const sessionRow = db.prepare('SELECT email FROM sessions WHERE id = 1').get();
-  if (!sessionRow) {
-    return res.json(null);
-  }
-
-  const userRow = db.prepare('SELECT payload FROM users WHERE email = ?').get(sessionRow.email);
-  return res.json(normalizeUser(parseRowPayload(userRow)));
-});
-
-app.put('/api/session', (req, res) => {
-  const user = req.body;
-  if (!user || !user.email) {
-    return res.status(400).json({ error: 'User payload with email is required.' });
-  }
-
-  const email = String(user.email).toLowerCase();
-  const canonicalUser = normalizeUser({ ...user, email });
-  const stamp = nowIso();
-
-  const tx = db.transaction(() => {
+  const userRecord = getUserRecord(email);
+  if (userRecord) {
+    const otp = String(Math.floor(100000 + Math.random() * 900000));
+    const stamp = nowIso();
     db.prepare(`
-      INSERT INTO users(email, payload, created_at, updated_at)
-      VALUES(@email, @payload, @createdAt, @updatedAt)
+      INSERT INTO password_reset_codes(email, code_hash, expires_at, attempts, created_at, updated_at)
+      VALUES(@email, @codeHash, @expiresAt, 0, @createdAt, @updatedAt)
       ON CONFLICT(email) DO UPDATE SET
-        payload = excluded.payload,
+        code_hash = excluded.code_hash,
+        expires_at = excluded.expires_at,
+        attempts = 0,
         updated_at = excluded.updated_at
     `).run({
       email,
-      payload: JSON.stringify(canonicalUser),
+      codeHash: hashOtp(otp),
+      expiresAt: new Date(Date.now() + PASSWORD_RESET_OTP_TTL_MS).toISOString(),
       createdAt: stamp,
       updatedAt: stamp
     });
 
-    db.prepare(`
-      INSERT INTO sessions(id, email, updated_at)
-      VALUES(1, ?, ?)
-      ON CONFLICT(id) DO UPDATE SET
-        email = excluded.email,
-        updated_at = excluded.updated_at
-    `).run(email, stamp);
+    if (!IS_PROD) {
+      return res.json({ ok: true, otpHint: otp });
+    }
+  }
+
+  return res.json({ ok: true });
+});
+
+app.post('/api/auth/verify-password-reset', authLimiter, (req, res) => {
+  const email = normalizeEmail(req.body?.email);
+  const otp = String(req.body?.otp || '').trim();
+  if (!email || !isValidEmail(email) || !/^\d{6}$/.test(otp)) {
+    return res.status(400).json({ error: 'Invalid email or OTP format.' });
+  }
+
+  const row = db
+    .prepare('SELECT email, code_hash, expires_at, attempts FROM password_reset_codes WHERE email = ?')
+    .get(email);
+  if (!row) {
+    return res.status(400).json({ error: 'Invalid or expired verification code.' });
+  }
+
+  if (new Date(row.expires_at).getTime() < Date.now()) {
+    db.prepare('DELETE FROM password_reset_codes WHERE email = ?').run(email);
+    return res.status(400).json({ error: 'Invalid or expired verification code.' });
+  }
+
+  if (row.code_hash !== hashOtp(otp)) {
+    const attempts = Number(row.attempts || 0) + 1;
+    if (attempts >= 5) {
+      db.prepare('DELETE FROM password_reset_codes WHERE email = ?').run(email);
+    } else {
+      db.prepare('UPDATE password_reset_codes SET attempts = ?, updated_at = ? WHERE email = ?').run(
+        attempts,
+        nowIso(),
+        email
+      );
+    }
+    return res.status(400).json({ error: 'Invalid or expired verification code.' });
+  }
+
+  db.prepare('DELETE FROM password_reset_codes WHERE email = ?').run(email);
+  const resetToken = jwt.sign({ sub: email, purpose: 'password-reset' }, RESET_TOKEN_SECRET, {
+    expiresIn: '10m'
+  });
+  return res.json({ ok: true, resetToken });
+});
+
+app.post('/api/auth/reset-password', authLimiter, (req, res) => {
+  const resetToken = String(req.body?.resetToken || '');
+  const newPassword = String(req.body?.newPassword || '');
+  if (!resetToken) {
+    return res.status(400).json({ error: 'Reset token is required.' });
+  }
+  if (newPassword.length < 6) {
+    return res.status(400).json({ error: 'Password must be at least 6 characters.' });
+  }
+
+  let decoded;
+  try {
+    decoded = jwt.verify(resetToken, RESET_TOKEN_SECRET);
+  } catch {
+    return res.status(400).json({ error: 'Invalid or expired reset token.' });
+  }
+
+  const email = normalizeEmail(decoded?.sub);
+  if (!email || decoded?.purpose !== 'password-reset') {
+    return res.status(400).json({ error: 'Invalid or expired reset token.' });
+  }
+
+  const record = getUserRecord(email);
+  if (!record) {
+    return res.status(404).json({ error: 'User not found.' });
+  }
+
+  upsertUser({
+    email,
+    user: record.user,
+    passwordHash: hashPassword(newPassword),
+    createdAt: record.createdAt
   });
 
-  tx();
+  return res.json({ ok: true });
+});
+
+app.get('/api/users', requireAuth, requireAdmin, (_req, res) => {
+  const rows = db.prepare('SELECT payload FROM users').all();
+  res.json(rows.map(parseRowPayload).map(normalizeUser));
+});
+
+app.get('/api/users/:email', requireAuth, (req, res) => {
+  const email = normalizeEmail(req.params.email);
+  if (!email) {
+    return res.status(400).json({ error: 'Invalid email.' });
+  }
+  if (req.auth.user.role !== 'Admin' && req.auth.email !== email) {
+    return res.status(403).json({ error: 'Forbidden.' });
+  }
+  const row = db.prepare('SELECT payload FROM users WHERE email = ?').get(email);
+  if (!row) {
+    return res.status(404).json({ error: 'User not found.' });
+  }
+  return res.json(normalizeUser(parseRowPayload(row)));
+});
+
+app.post('/api/users', requireAuth, requireAdmin, (req, res) => {
+  const user = req.body;
+  if (!user || !user.email) {
+    return res.status(400).json({ error: 'User payload with email is required.' });
+  }
+
+  const email = normalizeEmail(user.email);
+  const existing = db.prepare('SELECT email FROM users WHERE email = ?').get(email);
+  if (existing) {
+    return res.status(409).json({ error: 'User already exists.' });
+  }
+  const password = typeof user.password === 'string' && user.password.length >= 6 ? user.password : 'password';
+
+  const canonicalUser = normalizeUser({ ...user, email, trophies: user.trophies ?? 0 });
+  upsertUser({
+    email,
+    user: canonicalUser,
+    passwordHash: hashPassword(password)
+  });
+
+  return res.status(201).json({ ok: true });
+});
+
+app.put('/api/users/:email', requireAuth, (req, res) => {
+  const email = normalizeEmail(req.params.email);
+  const user = req.body;
+  if (!user) {
+    return res.status(400).json({ error: 'User payload is required.' });
+  }
+  if (req.auth.user.role !== 'Admin' && req.auth.email !== email) {
+    return res.status(403).json({ error: 'Forbidden.' });
+  }
+
+  const existing = getUserRecord(email);
+  const safeRole =
+    req.auth.user.role === 'Admin' && VALID_ROLES.has(user.role)
+      ? user.role
+      : existing?.user?.role || req.auth.user.role;
+  const canonicalUser = normalizeUser({ ...existing?.user, ...user, email, role: safeRole });
+  upsertUser({
+    email,
+    user: canonicalUser,
+    passwordHash: existing?.passwordHash || hashPassword('password'),
+    createdAt: existing?.createdAt
+  });
+
+  return res.json({ ok: true });
+});
+
+app.patch('/api/users/:email/password', requireAuth, (req, res) => {
+  const email = normalizeEmail(req.params.email);
+  const { password } = req.body || {};
+  if (!password || typeof password !== 'string' || password.length < 6) {
+    return res.status(400).json({ error: 'Password must be at least 6 characters.' });
+  }
+  if (req.auth.user.role !== 'Admin' && req.auth.email !== email) {
+    return res.status(403).json({ error: 'Forbidden.' });
+  }
+
+  const record = getUserRecord(email);
+  if (!record) {
+    return res.status(404).json({ error: 'User not found.' });
+  }
+
+  upsertUser({
+    email,
+    user: record.user,
+    passwordHash: hashPassword(password),
+    createdAt: record.createdAt
+  });
+  return res.json({ ok: true });
+});
+
+app.get('/api/session', (req, res) => {
+  const auth = getAuthFromRequest(req);
+  if (!auth) {
+    return res.json(null);
+  }
+  return res.json(auth.user);
+});
+
+app.put('/api/session', requireAuth, (req, res) => {
+  const user = req.body;
+  if (!user || !user.email) {
+    return res.status(400).json({ error: 'User payload with email is required.' });
+  }
+
+  const email = normalizeEmail(user.email);
+  if (req.auth.user.role !== 'Admin' && req.auth.email !== email) {
+    return res.status(403).json({ error: 'Forbidden.' });
+  }
+  const existing = getUserRecord(email);
+  const canonicalUser = normalizeUser({
+    ...existing?.user,
+    ...user,
+    email,
+    role: existing?.user?.role || req.auth.user.role
+  });
+  upsertUser({
+    email,
+    user: canonicalUser,
+    passwordHash: existing?.passwordHash || req.auth.passwordHash || hashPassword('password'),
+    createdAt: existing?.createdAt
+  });
   return res.json({ ok: true });
 });
 
 app.delete('/api/session', (_req, res) => {
-  db.prepare('DELETE FROM sessions WHERE id = 1').run();
-  res.json({ ok: true });
+  clearSessionCookie(res);
+  return res.json({ ok: true });
 });
 
-app.get('/api/analytics', (_req, res) => {
+app.get('/api/analytics', requireAuth, requireAdmin, (_req, res) => {
   const row = db.prepare('SELECT payload FROM analytics WHERE id = 1').get();
   if (!row) {
     return res.json(defaultAnalytics());
@@ -398,7 +804,49 @@ app.get('/api/analytics', (_req, res) => {
   return res.json(parseRowPayload(row));
 });
 
-app.put('/api/analytics', (req, res) => {
+app.post('/api/analytics/drill-complete', requireAuth, (req, res) => {
+  const result = req.body || {};
+  if (!VALID_DISASTER_TYPES.has(result.disasterType)) {
+    return res.status(400).json({ error: 'Invalid disaster type.' });
+  }
+  if (!VALID_DRILL_MODES.has(result.mode)) {
+    return res.status(400).json({ error: 'Invalid drill mode.' });
+  }
+
+  const analytics = parseRowPayload(db.prepare('SELECT payload FROM analytics WHERE id = 1').get()) || defaultAnalytics();
+  analytics.totalDrillsCompleted = Number(analytics.totalDrillsCompleted || 0) + 1;
+  analytics.drillsByType = analytics.drillsByType || {};
+  analytics.scoresByType = analytics.scoresByType || {};
+  analytics.drillsByType[result.disasterType] = Number(analytics.drillsByType[result.disasterType] || 0) + 1;
+
+  if (
+    result.mode === 'Standard' &&
+    isFiniteNumber(result.score) &&
+    isFiniteNumber(result.totalQuestions) &&
+    result.totalQuestions > 0
+  ) {
+    analytics.overallScoreSum = Number(analytics.overallScoreSum || 0) + Math.round(result.score);
+    analytics.overallQuestionSum = Number(analytics.overallQuestionSum || 0) + Math.round(result.totalQuestions);
+    const byType = analytics.scoresByType[result.disasterType] || { scoreSum: 0, questionSum: 0, count: 0 };
+    analytics.scoresByType[result.disasterType] = {
+      scoreSum: Number(byType.scoreSum || 0) + Math.round(result.score),
+      questionSum: Number(byType.questionSum || 0) + Math.round(result.totalQuestions),
+      count: Number(byType.count || 0) + 1
+    };
+  }
+
+  db.prepare(`
+    INSERT INTO analytics(id, payload, updated_at)
+    VALUES(1, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      payload = excluded.payload,
+      updated_at = excluded.updated_at
+  `).run(JSON.stringify(analytics), nowIso());
+
+  return res.json({ ok: true });
+});
+
+app.put('/api/analytics', requireAuth, requireAdmin, (req, res) => {
   const payload = req.body;
   if (!payload) {
     return res.status(400).json({ error: 'Analytics payload is required.' });
@@ -413,6 +861,250 @@ app.put('/api/analytics', (req, res) => {
   `).run(JSON.stringify(payload), nowIso());
 
   return res.json({ ok: true });
+});
+
+const drillResponseSchema = {
+  type: Type.OBJECT,
+  properties: {
+    scenario: {
+      type: Type.STRING,
+      description: 'A detailed paragraph describing a disaster situation unfolding in a school.'
+    },
+    question: {
+      type: Type.STRING,
+      description: 'A clear question asking the immediate next action.'
+    },
+    options: {
+      type: Type.ARRAY,
+      description: 'An array of exactly three possible actions.',
+      items: {
+        type: Type.OBJECT,
+        properties: {
+          text: { type: Type.STRING },
+          isCorrect: { type: Type.BOOLEAN },
+          feedback: { type: Type.STRING }
+        },
+        required: ['text', 'isCorrect', 'feedback']
+      }
+    },
+    aiAdvice: {
+      type: Type.STRING,
+      description: 'A concise actionable hint.'
+    }
+  },
+  required: ['scenario', 'question', 'options', 'aiAdvice']
+};
+
+const ensureAiReady = (res) => {
+  if (!ai || !GEMINI_API_KEY) {
+    res.status(503).json({ error: 'GEMINI_API_KEY is not configured.' });
+    return false;
+  }
+  return true;
+};
+
+const generateDrillScenario = async (disasterType, region, mode, previousStepContext) => {
+  const studentFocus = 'All scenarios and options must be easy for a school student in India to understand.';
+  let prompt = '';
+
+  if (previousStepContext) {
+    const { scenario, question, userAnswer, stepsSurvived } = previousStepContext;
+    if (mode === 'Survival') {
+      prompt = `This is a continuous SURVIVAL MODE disaster drill about a ${disasterType} in a school in ${region}, India. The user has correctly survived ${stepsSurvived} scenarios so far.
+The previous situation was: "${scenario}".
+The user correctly chose the action: "${userAnswer?.text || ''}".
+Generate the next logical follow-up scenario in this evolving story. It should become slightly more intense while staying realistic for a student perspective. Create one question and three options with one correct answer. ${studentFocus}`;
+    } else {
+      prompt = `This is a multi-step standard disaster drill for a ${disasterType} in a school in ${region}, India.
+The previous situation was: "${scenario}".
+The question asked was: "${question}".
+The user chose the action: "${userAnswer?.text || ''}", which was ${userAnswer?.isCorrect ? 'correct' : 'incorrect'}.
+Generate a logical follow-up scenario, with one new question and three options (one correct). ${studentFocus}`;
+    }
+  } else {
+    const modeDescription = mode === 'Survival'
+      ? 'This is the start of a continuous SURVIVAL MODE drill.'
+      : 'This is the start of a standard multi-step drill.';
+    prompt = `Generate a realistic initial-stage disaster scenario for a ${disasterType} in a school located in ${region}, India. ${modeDescription}
+Use a student perspective. Create one question with exactly three options, one correct and two plausible incorrect, plus brief feedback and a concise hint. ${studentFocus}`;
+  }
+
+  const response = await ai.models.generateContent({
+    model: 'gemini-2.5-flash',
+    contents: prompt,
+    config: {
+      responseMimeType: 'application/json',
+      responseSchema: drillResponseSchema,
+      temperature: 0.8
+    }
+  });
+
+  const parsed = JSON.parse(response.text.trim());
+  const options = Array.isArray(parsed?.options) ? parsed.options : [];
+  const valid =
+    typeof parsed?.scenario === 'string' &&
+    typeof parsed?.question === 'string' &&
+    typeof parsed?.aiAdvice === 'string' &&
+    options.length === 3 &&
+    options.every(
+      (option) =>
+        typeof option?.text === 'string' &&
+        typeof option?.isCorrect === 'boolean' &&
+        typeof option?.feedback === 'string'
+    );
+
+  return valid ? parsed : null;
+};
+
+const generateSafetyTips = async (context) => {
+  let contextDescription;
+  switch (context) {
+    case 'home':
+      contextDescription = 'on the main home screen of the app. Give general preparedness tips.';
+      break;
+    case 'modules':
+      contextDescription = 'looking at the list of disaster modules. Give tips about the importance of learning.';
+      break;
+    case 'drills':
+      contextDescription = 'in the drills lobby, preparing to start a simulation. Give tips on how to approach a drill.';
+      break;
+    case 'Earthquake':
+    case 'Flood':
+    case 'Fire':
+    case 'Cyclone':
+      contextDescription = `studying the '${context}' disaster module. Give specific tips for this disaster.`;
+      break;
+    default:
+      contextDescription = 'using the app. Give general safety tips.';
+      break;
+  }
+
+  const prompt = `You are an AI Safety Advisor for the CrisisGuardian app. A user is currently ${contextDescription}
+Generate 3 to 5 concise, actionable safety tips for students in India.
+Format each tip on a new line and prefix each line with an emoji. Avoid markdown bullets.`;
+
+  const response = await ai.models.generateContent({
+    model: 'gemini-2.5-flash',
+    contents: prompt,
+    config: { temperature: 0.7 }
+  });
+
+  return response.text;
+};
+
+const generateVideoLesson = async (disasterType, videoStyle) => {
+  const styleDescription =
+    videoStyle === 'cartoon'
+      ? 'an engaging, clear, and friendly 2D animated cartoon style suitable for students. Simple characters, bright colors.'
+      : 'a realistic, high-fidelity simulation with a serious but non-graphic tone.';
+
+  const coreContent = {
+    Earthquake:
+      "A school classroom starts shaking. Students practice 'Drop, Cover, and Hold On' under desks. Show evacuation to an open assembly point. End with title card: Earthquake Safety: Drop, Cover, Hold On!",
+    Flood:
+      "Heavy rain causes water to rise around a school. Show students calmly moving to a higher floor. Show a car being swept away with text: Turn Around, Don't Drown. End with title card: Flood Preparedness: Stay Safe, Stay Dry.",
+    Fire:
+      'A smoke alarm blares in a school hallway. Show students crawling low under smoke. A teacher demonstrates PASS extinguisher method on a controlled fire. Evacuate to assembly point. End with title card: Fire Emergency: Get Out, Stay Out!',
+    Cyclone:
+      'Strong winds and rain lash school windows. Show students sheltered in a strong interior room away from windows. A tree branch falls outside. Show post-cyclone downed power lines. End with title card: Cyclone Alert: Weather the Storm Safely.'
+  };
+
+  const prompt = `Generate a short silent educational video (~30 seconds) about ${disasterType} safety in a school setting in India.
+The video style should be ${styleDescription}
+The scene should show: ${coreContent[disasterType]}`;
+
+  let operation = await ai.models.generateVideos({
+    model: 'veo-2.0-generate-001',
+    prompt,
+    config: { numberOfVideos: 1 }
+  });
+
+  while (!operation.done) {
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+    operation = await ai.operations.getVideosOperation({ operation });
+  }
+
+  const downloadLink = operation.response?.generatedVideos?.[0]?.video?.uri;
+  if (!downloadLink) {
+    return null;
+  }
+
+  const response = await fetch(`${downloadLink}&key=${GEMINI_API_KEY}`);
+  if (!response.ok) {
+    return null;
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const contentType = response.headers.get('content-type') || 'video/mp4';
+  return { buffer: Buffer.from(arrayBuffer), contentType };
+};
+
+app.post('/api/ai/drill-scenario', requireAuth, aiLimiter, async (req, res) => {
+  if (!ensureAiReady(res)) return;
+
+  const { disasterType, region, mode, previousStepContext } = req.body || {};
+  if (!VALID_DISASTER_TYPES.has(disasterType)) {
+    return res.status(400).json({ error: 'Invalid disaster type.' });
+  }
+  if (!VALID_DRILL_MODES.has(mode)) {
+    return res.status(400).json({ error: 'Invalid drill mode.' });
+  }
+  if (typeof region !== 'string' || !region.trim()) {
+    return res.status(400).json({ error: 'Region is required.' });
+  }
+
+  try {
+    const scenario = await generateDrillScenario(disasterType, region.trim(), mode, previousStepContext);
+    if (!scenario) {
+      return res.status(502).json({ error: 'Failed to generate scenario.' });
+    }
+    return res.json(scenario);
+  } catch (error) {
+    console.error('Error generating drill scenario:', error);
+    return res.status(502).json({ error: 'AI scenario generation failed.' });
+  }
+});
+
+app.post('/api/ai/safety-tips', requireAuth, aiLimiter, async (req, res) => {
+  if (!ensureAiReady(res)) return;
+
+  const { context } = req.body || {};
+  if (typeof context !== 'string' || !context.trim()) {
+    return res.status(400).json({ error: 'Context is required.' });
+  }
+
+  try {
+    const tips = await generateSafetyTips(context.trim());
+    return res.json({ tips });
+  } catch (error) {
+    console.error('Error generating safety tips:', error);
+    return res.status(502).json({ error: 'AI safety tips generation failed.' });
+  }
+});
+
+app.post('/api/ai/video-lesson', requireAuth, aiLimiter, async (req, res) => {
+  if (!ensureAiReady(res)) return;
+
+  const { disasterType, videoStyle } = req.body || {};
+  if (!VALID_DISASTER_TYPES.has(disasterType)) {
+    return res.status(400).json({ error: 'Invalid disaster type.' });
+  }
+  if (!VALID_VIDEO_STYLES.has(videoStyle)) {
+    return res.status(400).json({ error: 'Invalid video style.' });
+  }
+
+  try {
+    const generated = await generateVideoLesson(disasterType, videoStyle);
+    if (!generated) {
+      return res.status(502).json({ error: 'Failed to generate video lesson.' });
+    }
+    res.setHeader('Content-Type', generated.contentType);
+    res.setHeader('Cache-Control', 'no-store');
+    return res.send(generated.buffer);
+  } catch (error) {
+    console.error('Error generating video lesson:', error);
+    return res.status(502).json({ error: 'AI video generation failed.' });
+  }
 });
 
 // Serve frontend build in production deployment.

--- a/server/index.js
+++ b/server/index.js
@@ -20,7 +20,10 @@ const app = express();
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const IS_PROD = NODE_ENV === 'production';
 const PORT = Number(process.env.PORT || process.env.API_PORT || 3001);
-const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN;
+const FRONTEND_ORIGIN =
+  process.env.FRONTEND_ORIGIN ||
+  process.env.RENDER_EXTERNAL_URL ||
+  process.env.APP_ORIGIN;
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-change-this-jwt-secret';
 const SIGNUP_TOKEN_SECRET = process.env.SIGNUP_TOKEN_SECRET || `${JWT_SECRET}-signup`;
 const RESET_TOKEN_SECRET = process.env.RESET_TOKEN_SECRET || `${JWT_SECRET}-reset`;

--- a/server/index.js
+++ b/server/index.js
@@ -21,10 +21,13 @@ const IS_PROD = NODE_ENV === 'production';
 const PORT = Number(process.env.PORT || process.env.API_PORT || 3001);
 const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN;
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-change-this-jwt-secret';
+const SIGNUP_TOKEN_SECRET = process.env.SIGNUP_TOKEN_SECRET || `${JWT_SECRET}-signup`;
 const RESET_TOKEN_SECRET = process.env.RESET_TOKEN_SECRET || `${JWT_SECRET}-reset`;
 const SESSION_COOKIE_NAME = 'cg_session';
 const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 7;
+const SIGNUP_OTP_TTL_MS = 1000 * 60 * 5;
 const PASSWORD_RESET_OTP_TTL_MS = 1000 * 60 * 5;
+const OTP_MAX_ATTEMPTS = 5;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const DB_DIR = path.resolve(process.cwd(), 'data');
 const DB_PATH = path.join(DB_DIR, 'crisisguardian.db');
@@ -75,6 +78,15 @@ CREATE TABLE IF NOT EXISTS password_reset_codes (
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   FOREIGN KEY(email) REFERENCES users(email)
+);
+
+CREATE TABLE IF NOT EXISTS signup_verification_codes (
+  email TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
 );
 `);
 
@@ -138,6 +150,73 @@ const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 const hashPassword = (password) => bcrypt.hashSync(password, 12);
 const verifyPassword = (password, hash) => bcrypt.compareSync(password, hash);
 const hashOtp = (otp) => crypto.createHash('sha256').update(String(otp)).digest('hex');
+const OTP_TABLES = {
+  signup: 'signup_verification_codes',
+  passwordReset: 'password_reset_codes'
+};
+
+const getOtpTableName = (purpose) => OTP_TABLES[purpose];
+
+const issueOtpCode = ({ purpose, email, ttlMs }) => {
+  const table = getOtpTableName(purpose);
+  if (!table) throw new Error('Unknown OTP purpose.');
+
+  const otp = String(Math.floor(100000 + Math.random() * 900000));
+  const stamp = nowIso();
+
+  db.prepare(`
+    INSERT INTO ${table}(email, code_hash, expires_at, attempts, created_at, updated_at)
+    VALUES(@email, @codeHash, @expiresAt, 0, @createdAt, @updatedAt)
+    ON CONFLICT(email) DO UPDATE SET
+      code_hash = excluded.code_hash,
+      expires_at = excluded.expires_at,
+      attempts = 0,
+      updated_at = excluded.updated_at
+  `).run({
+    email,
+    codeHash: hashOtp(otp),
+    expiresAt: new Date(Date.now() + ttlMs).toISOString(),
+    createdAt: stamp,
+    updatedAt: stamp
+  });
+
+  return otp;
+};
+
+const verifyAndConsumeOtpCode = ({ purpose, email, otp }) => {
+  const table = getOtpTableName(purpose);
+  if (!table) throw new Error('Unknown OTP purpose.');
+
+  const row = db
+    .prepare(`SELECT email, code_hash, expires_at, attempts FROM ${table} WHERE email = ?`)
+    .get(email);
+
+  if (!row) {
+    return false;
+  }
+
+  if (new Date(row.expires_at).getTime() < Date.now()) {
+    db.prepare(`DELETE FROM ${table} WHERE email = ?`).run(email);
+    return false;
+  }
+
+  if (row.code_hash !== hashOtp(otp)) {
+    const attempts = Number(row.attempts || 0) + 1;
+    if (attempts >= OTP_MAX_ATTEMPTS) {
+      db.prepare(`DELETE FROM ${table} WHERE email = ?`).run(email);
+    } else {
+      db.prepare(`UPDATE ${table} SET attempts = ?, updated_at = ? WHERE email = ?`).run(
+        attempts,
+        nowIso(),
+        email
+      );
+    }
+    return false;
+  }
+
+  db.prepare(`DELETE FROM ${table} WHERE email = ?`).run(email);
+  return true;
+};
 
 const parseRowPayload = (row) => {
   if (!row) return null;
@@ -478,8 +557,45 @@ app.post('/api/auth/check-email', authLimiter, (req, res) => {
   return res.json({ exists });
 });
 
+app.post('/api/auth/request-signup-otp', authLimiter, (req, res) => {
+  const email = normalizeEmail(req.body?.email);
+  if (!email || !isValidEmail(email)) {
+    return res.status(400).json({ error: 'Valid email is required.' });
+  }
+  if (getUserRecord(email)) {
+    return res.status(409).json({ error: 'An account with this email already exists.' });
+  }
+
+  const otp = issueOtpCode({ purpose: 'signup', email, ttlMs: SIGNUP_OTP_TTL_MS });
+  if (!IS_PROD) {
+    return res.json({ ok: true, otpHint: otp });
+  }
+  return res.json({ ok: true });
+});
+
+app.post('/api/auth/verify-signup-otp', authLimiter, (req, res) => {
+  const email = normalizeEmail(req.body?.email);
+  const otp = String(req.body?.otp || '').trim();
+  if (!email || !isValidEmail(email) || !/^\d{6}$/.test(otp)) {
+    return res.status(400).json({ error: 'Invalid email or OTP format.' });
+  }
+  if (getUserRecord(email)) {
+    return res.status(409).json({ error: 'An account with this email already exists.' });
+  }
+
+  const verified = verifyAndConsumeOtpCode({ purpose: 'signup', email, otp });
+  if (!verified) {
+    return res.status(400).json({ error: 'Invalid or expired verification code.' });
+  }
+
+  const signupToken = jwt.sign({ sub: email, purpose: 'signup-verified' }, SIGNUP_TOKEN_SECRET, {
+    expiresIn: '10m'
+  });
+  return res.json({ ok: true, signupToken });
+});
+
 app.post('/api/auth/signup', authLimiter, (req, res) => {
-  const { name, email, password, role, institution, phone, avatar } = req.body || {};
+  const { name, email, password, role, institution, phone, avatar, signupToken } = req.body || {};
   const normalizedEmail = normalizeEmail(email);
 
   if (!normalizedEmail || !isValidEmail(normalizedEmail)) {
@@ -496,6 +612,23 @@ app.post('/api/auth/signup', authLimiter, (req, res) => {
   }
   if (typeof institution !== 'string' || !institution.trim()) {
     return res.status(400).json({ error: 'Institution is required.' });
+  }
+  if (!signupToken || typeof signupToken !== 'string') {
+    return res.status(400).json({ error: 'Signup verification is required.' });
+  }
+
+  let decodedSignupToken;
+  try {
+    decodedSignupToken = jwt.verify(signupToken, SIGNUP_TOKEN_SECRET);
+  } catch {
+    return res.status(400).json({ error: 'Invalid or expired signup verification token.' });
+  }
+
+  if (decodedSignupToken?.purpose !== 'signup-verified') {
+    return res.status(400).json({ error: 'Invalid signup verification token.' });
+  }
+  if (normalizeEmail(decodedSignupToken?.sub) !== normalizedEmail) {
+    return res.status(400).json({ error: 'Signup verification token does not match this email.' });
   }
 
   if (getUserRecord(normalizedEmail)) {
@@ -561,23 +694,7 @@ app.post('/api/auth/request-password-reset', authLimiter, (req, res) => {
 
   const userRecord = getUserRecord(email);
   if (userRecord) {
-    const otp = String(Math.floor(100000 + Math.random() * 900000));
-    const stamp = nowIso();
-    db.prepare(`
-      INSERT INTO password_reset_codes(email, code_hash, expires_at, attempts, created_at, updated_at)
-      VALUES(@email, @codeHash, @expiresAt, 0, @createdAt, @updatedAt)
-      ON CONFLICT(email) DO UPDATE SET
-        code_hash = excluded.code_hash,
-        expires_at = excluded.expires_at,
-        attempts = 0,
-        updated_at = excluded.updated_at
-    `).run({
-      email,
-      codeHash: hashOtp(otp),
-      expiresAt: new Date(Date.now() + PASSWORD_RESET_OTP_TTL_MS).toISOString(),
-      createdAt: stamp,
-      updatedAt: stamp
-    });
+    const otp = issueOtpCode({ purpose: 'passwordReset', email, ttlMs: PASSWORD_RESET_OTP_TTL_MS });
 
     if (!IS_PROD) {
       return res.json({ ok: true, otpHint: otp });
@@ -594,33 +711,10 @@ app.post('/api/auth/verify-password-reset', authLimiter, (req, res) => {
     return res.status(400).json({ error: 'Invalid email or OTP format.' });
   }
 
-  const row = db
-    .prepare('SELECT email, code_hash, expires_at, attempts FROM password_reset_codes WHERE email = ?')
-    .get(email);
-  if (!row) {
+  const verified = verifyAndConsumeOtpCode({ purpose: 'passwordReset', email, otp });
+  if (!verified) {
     return res.status(400).json({ error: 'Invalid or expired verification code.' });
   }
-
-  if (new Date(row.expires_at).getTime() < Date.now()) {
-    db.prepare('DELETE FROM password_reset_codes WHERE email = ?').run(email);
-    return res.status(400).json({ error: 'Invalid or expired verification code.' });
-  }
-
-  if (row.code_hash !== hashOtp(otp)) {
-    const attempts = Number(row.attempts || 0) + 1;
-    if (attempts >= 5) {
-      db.prepare('DELETE FROM password_reset_codes WHERE email = ?').run(email);
-    } else {
-      db.prepare('UPDATE password_reset_codes SET attempts = ?, updated_at = ? WHERE email = ?').run(
-        attempts,
-        nowIso(),
-        email
-      );
-    }
-    return res.status(400).json({ error: 'Invalid or expired verification code.' });
-  }
-
-  db.prepare('DELETE FROM password_reset_codes WHERE email = ?').run(email);
   const resetToken = jwt.sign({ sub: email, purpose: 'password-reset' }, RESET_TOKEN_SECRET, {
     expiresIn: '10m'
   });

--- a/services/analyticsService.ts
+++ b/services/analyticsService.ts
@@ -2,6 +2,7 @@ import { AnalyticsData, DrillResult } from '../types';
 
 const apiFetch = async <T>(path: string, init?: RequestInit): Promise<T> => {
   const response = await fetch(`/api${path}`, {
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       ...(init?.headers || {}),
@@ -40,23 +41,8 @@ const saveAnalytics = async (data: AnalyticsData): Promise<void> => {
 };
 
 export const updateAnalyticsOnDrillComplete = async (result: DrillResult): Promise<void> => {
-  const data = await getAnalytics();
-
-  data.totalDrillsCompleted += 1;
-  data.drillsByType[result.disasterType] = (data.drillsByType[result.disasterType] || 0) + 1;
-
-  if (result.mode === 'Standard' && result.score !== undefined && result.totalQuestions !== undefined) {
-    const { disasterType, score, totalQuestions } = result;
-
-    data.overallScoreSum += score;
-    data.overallQuestionSum += totalQuestions;
-
-    const typeScores = data.scoresByType[disasterType] || { scoreSum: 0, questionSum: 0, count: 0 };
-    typeScores.scoreSum += score;
-    typeScores.questionSum += totalQuestions;
-    typeScores.count += 1;
-    data.scoresByType[disasterType] = typeScores;
-  }
-
-  await saveAnalytics(data);
+  await apiFetch<{ ok: boolean }>('/analytics/drill-complete', {
+    method: 'POST',
+    body: JSON.stringify(result),
+  });
 };

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -1,7 +1,7 @@
-// services/authService.ts
 import { User } from '../types';
 
-const OTP_KEY = 'crisis_guardian_otp';
+const SIGNUP_OTP_KEY = 'crisis_guardian_signup_otp';
+const RESET_TOKEN_KEY = 'crisis_guardian_reset_token';
 
 interface InstitutionsDB {
   schools: string[];
@@ -14,6 +14,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const apiFetch = async <T>(path: string, init?: RequestInit): Promise<T> => {
   const response = await fetch(`/api${path}`, {
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       ...(init?.headers || {}),
@@ -22,7 +23,20 @@ const apiFetch = async <T>(path: string, init?: RequestInit): Promise<T> => {
   });
 
   if (!response.ok) {
-    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+    let message = `API request failed: ${response.status} ${response.statusText}`;
+    try {
+      const payload = await response.json();
+      if (payload?.error && typeof payload.error === 'string') {
+        message = payload.error;
+      }
+    } catch {
+      // Ignore JSON parse failure on error payloads.
+    }
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
   }
 
   return (await response.json()) as T;
@@ -58,18 +72,37 @@ export const seedInitialUsers = async (): Promise<void> => {
   await apiFetch<{ ok: boolean }>('/seed', { method: 'POST' });
 };
 
+export const isEmailRegistered = async (email: string): Promise<boolean> => {
+  try {
+    const payload = await apiFetch<{ exists: boolean }>('/auth/check-email', {
+      method: 'POST',
+      body: JSON.stringify({ email: email.toLowerCase() }),
+    });
+    return Boolean(payload.exists);
+  } catch {
+    return false;
+  }
+};
+
 export const findUserByEmail = async (email: string): Promise<User | null> => {
-  await wait(MOCK_API_LATENCY / 2);
-  const encodedEmail = encodeURIComponent(email.toLowerCase());
-  return apiFetch<User | null>(`/users/${encodedEmail}`);
+  const exists = await isEmailRegistered(email);
+  return exists ? ({ email: email.toLowerCase() } as User) : null;
 };
 
 export const createUser = async (user: User): Promise<boolean> => {
   try {
     await wait(MOCK_API_LATENCY);
-    await apiFetch<{ ok: boolean }>('/users', {
+    await apiFetch<{ user: User }>('/auth/signup', {
       method: 'POST',
-      body: JSON.stringify({ ...user, email: user.email.toLowerCase(), trophies: user.trophies ?? 0 }),
+      body: JSON.stringify({
+        name: user.name,
+        email: user.email.toLowerCase(),
+        password: user.password,
+        role: user.role,
+        institution: user.institution,
+        phone: user.phone,
+        avatar: user.avatar,
+      }),
     });
     return true;
   } catch {
@@ -78,61 +111,20 @@ export const createUser = async (user: User): Promise<boolean> => {
 };
 
 export const loginUser = async (email: string, password: string): Promise<User | null> => {
-  const user = await findUserByEmail(email);
-  if (user && user.password === password) {
-    return user;
-  }
-  return null;
-};
-
-export const updatePassword = async (email: string, newPassword: string): Promise<boolean> => {
   try {
-    await wait(MOCK_API_LATENCY);
-    const encodedEmail = encodeURIComponent(email.toLowerCase());
-    await apiFetch<{ ok: boolean }>(`/users/${encodedEmail}/password`, {
-      method: 'PATCH',
-      body: JSON.stringify({ password: newPassword }),
+    await wait(MOCK_API_LATENCY / 2);
+    const payload = await apiFetch<{ user: User }>('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email: email.toLowerCase(), password }),
     });
-    return true;
+    return payload.user;
   } catch {
-    return false;
+    return null;
   }
 };
-
-// --- OTP Simulation (sessionStorage + console.log) ---
-
-export const sendOtp = (email: string): string => {
-  const otp = Math.floor(100000 + Math.random() * 900000).toString();
-  const otpData = { email: email.toLowerCase(), otp, timestamp: Date.now() };
-
-  sessionStorage.setItem(OTP_KEY, JSON.stringify(otpData));
-
-  console.log(`%c[CrisisGuardian] OTP for ${email}: ${otp}`, 'color: #0ea5e9; font-weight: bold; font-size: 14px;');
-  console.log('%cThis is a simulated OTP. In a real app, this would be sent via email or SMS.', 'color: #64748b;');
-
-  return otp;
-};
-
-export const verifyOtp = (email: string, otp: string): boolean => {
-  const otpDataString = sessionStorage.getItem(OTP_KEY);
-  if (!otpDataString) return false;
-
-  const otpData = JSON.parse(otpDataString);
-  const isEmailMatch = otpData.email === email.toLowerCase();
-  const isOtpMatch = otpData.otp === otp;
-  const isNotExpired = Date.now() - otpData.timestamp < 5 * 60 * 1000;
-
-  if (isEmailMatch && isOtpMatch && isNotExpired) {
-    sessionStorage.removeItem(OTP_KEY);
-    return true;
-  }
-  return false;
-};
-
-// --- Session Management via API ---
 
 export const createSession = async (user: User) => {
-  await wait(MOCK_API_LATENCY);
+  await wait(MOCK_API_LATENCY / 2);
   await apiFetch<{ ok: boolean }>('/session', {
     method: 'PUT',
     body: JSON.stringify({ ...user, email: user.email.toLowerCase() }),
@@ -141,10 +133,82 @@ export const createSession = async (user: User) => {
 
 export const checkSession = async (): Promise<User | null> => {
   await wait(MOCK_API_LATENCY / 2);
-  return apiFetch<User | null>('/session');
+  try {
+    const payload = await apiFetch<{ user: User }>('/auth/me');
+    return payload.user;
+  } catch {
+    return null;
+  }
 };
 
 export const clearSession = async () => {
-  await wait(MOCK_API_LATENCY);
-  await apiFetch<{ ok: boolean }>('/session', { method: 'DELETE' });
+  await wait(MOCK_API_LATENCY / 2);
+  clearPendingPasswordReset();
+  await apiFetch<{ ok: boolean }>('/auth/logout', { method: 'POST' });
+};
+
+export const sendSignupOtp = (email: string): string => {
+  const otp = Math.floor(100000 + Math.random() * 900000).toString();
+  const otpData = { email: email.toLowerCase(), otp, timestamp: Date.now() };
+  sessionStorage.setItem(SIGNUP_OTP_KEY, JSON.stringify(otpData));
+  return otp;
+};
+
+export const verifySignupOtp = (email: string, otp: string): boolean => {
+  const otpDataString = sessionStorage.getItem(SIGNUP_OTP_KEY);
+  if (!otpDataString) return false;
+
+  const otpData = JSON.parse(otpDataString);
+  const isEmailMatch = otpData.email === email.toLowerCase();
+  const isOtpMatch = otpData.otp === otp;
+  const isNotExpired = Date.now() - otpData.timestamp < 5 * 60 * 1000;
+
+  if (isEmailMatch && isOtpMatch && isNotExpired) {
+    sessionStorage.removeItem(SIGNUP_OTP_KEY);
+    return true;
+  }
+  return false;
+};
+
+export const requestPasswordReset = async (email: string): Promise<string | undefined> => {
+  await wait(MOCK_API_LATENCY / 2);
+  const payload = await apiFetch<{ ok: boolean; otpHint?: string }>('/auth/request-password-reset', {
+    method: 'POST',
+    body: JSON.stringify({ email: email.toLowerCase() }),
+  });
+  return payload.otpHint;
+};
+
+export const verifyPasswordResetOtp = async (email: string, otp: string): Promise<boolean> => {
+  try {
+    const payload = await apiFetch<{ ok: boolean; resetToken: string }>('/auth/verify-password-reset', {
+      method: 'POST',
+      body: JSON.stringify({ email: email.toLowerCase(), otp }),
+    });
+    sessionStorage.setItem(RESET_TOKEN_KEY, payload.resetToken);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const updatePassword = async (newPassword: string): Promise<boolean> => {
+  const resetToken = sessionStorage.getItem(RESET_TOKEN_KEY);
+  if (!resetToken) {
+    return false;
+  }
+  try {
+    await apiFetch<{ ok: boolean }>('/auth/reset-password', {
+      method: 'POST',
+      body: JSON.stringify({ resetToken, newPassword }),
+    });
+    sessionStorage.removeItem(RESET_TOKEN_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const clearPendingPasswordReset = () => {
+  sessionStorage.removeItem(RESET_TOKEN_KEY);
 };

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -1,6 +1,6 @@
 import { User } from '../types';
 
-const SIGNUP_OTP_KEY = 'crisis_guardian_signup_otp';
+const SIGNUP_TOKEN_KEY = 'crisis_guardian_signup_token';
 const RESET_TOKEN_KEY = 'crisis_guardian_reset_token';
 
 interface InstitutionsDB {
@@ -90,6 +90,11 @@ export const findUserByEmail = async (email: string): Promise<User | null> => {
 };
 
 export const createUser = async (user: User): Promise<boolean> => {
+  const signupToken = sessionStorage.getItem(SIGNUP_TOKEN_KEY);
+  if (!signupToken) {
+    return false;
+  }
+
   try {
     await wait(MOCK_API_LATENCY);
     await apiFetch<{ user: User }>('/auth/signup', {
@@ -102,8 +107,10 @@ export const createUser = async (user: User): Promise<boolean> => {
         institution: user.institution,
         phone: user.phone,
         avatar: user.avatar,
+        signupToken,
       }),
     });
+    sessionStorage.removeItem(SIGNUP_TOKEN_KEY);
     return true;
   } catch {
     return false;
@@ -143,31 +150,31 @@ export const checkSession = async (): Promise<User | null> => {
 
 export const clearSession = async () => {
   await wait(MOCK_API_LATENCY / 2);
+  clearPendingSignupVerification();
   clearPendingPasswordReset();
   await apiFetch<{ ok: boolean }>('/auth/logout', { method: 'POST' });
 };
 
-export const sendSignupOtp = (email: string): string => {
-  const otp = Math.floor(100000 + Math.random() * 900000).toString();
-  const otpData = { email: email.toLowerCase(), otp, timestamp: Date.now() };
-  sessionStorage.setItem(SIGNUP_OTP_KEY, JSON.stringify(otpData));
-  return otp;
+export const requestSignupOtp = async (email: string): Promise<string | undefined> => {
+  await wait(MOCK_API_LATENCY / 2);
+  const payload = await apiFetch<{ ok: boolean; otpHint?: string }>('/auth/request-signup-otp', {
+    method: 'POST',
+    body: JSON.stringify({ email: email.toLowerCase() }),
+  });
+  return payload.otpHint;
 };
 
-export const verifySignupOtp = (email: string, otp: string): boolean => {
-  const otpDataString = sessionStorage.getItem(SIGNUP_OTP_KEY);
-  if (!otpDataString) return false;
-
-  const otpData = JSON.parse(otpDataString);
-  const isEmailMatch = otpData.email === email.toLowerCase();
-  const isOtpMatch = otpData.otp === otp;
-  const isNotExpired = Date.now() - otpData.timestamp < 5 * 60 * 1000;
-
-  if (isEmailMatch && isOtpMatch && isNotExpired) {
-    sessionStorage.removeItem(SIGNUP_OTP_KEY);
+export const verifySignupOtp = async (email: string, otp: string): Promise<boolean> => {
+  try {
+    const payload = await apiFetch<{ ok: boolean; signupToken: string }>('/auth/verify-signup-otp', {
+      method: 'POST',
+      body: JSON.stringify({ email: email.toLowerCase(), otp }),
+    });
+    sessionStorage.setItem(SIGNUP_TOKEN_KEY, payload.signupToken);
     return true;
+  } catch {
+    return false;
   }
-  return false;
 };
 
 export const requestPasswordReset = async (email: string): Promise<string | undefined> => {
@@ -211,4 +218,8 @@ export const updatePassword = async (newPassword: string): Promise<boolean> => {
 
 export const clearPendingPasswordReset = () => {
   sessionStorage.removeItem(RESET_TOKEN_KEY);
+};
+
+export const clearPendingSignupVerification = () => {
+  sessionStorage.removeItem(SIGNUP_TOKEN_KEY);
 };

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,205 +1,84 @@
-import { GoogleGenAI, Type } from "@google/genai";
-import { DisasterType, DrillStep, DrillStepOption, DrillMode, VideoStyle } from '../types';
-
-
-const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
-
-const responseSchema = {
-  type: Type.OBJECT,
-  properties: {
-    scenario: {
-      type: Type.STRING,
-      description: "A detailed, immersive paragraph describing a disaster situation unfolding in a school.",
-    },
-    question: {
-        type: Type.STRING,
-        description: "A clear, direct question asking the user what their immediate next action should be."
-    },
-    options: {
-      type: Type.ARRAY,
-      description: "An array of exactly three possible actions the user can take.",
-      items: {
-        type: Type.OBJECT,
-        properties: {
-          text: {
-            type: Type.STRING,
-            description: "The text of the multiple-choice option.",
-          },
-          isCorrect: {
-            type: Type.BOOLEAN,
-            description: "A boolean indicating if this is the correct action.",
-          },
-          feedback: {
-              type: Type.STRING,
-              description: "A short explanation of why this option is correct or incorrect."
-          }
-        },
-        required: ["text", "isCorrect", "feedback"],
-      },
-    },
-    aiAdvice: {
-        type: Type.STRING,
-        description: "A short, concise, and actionable hint for the user if they are stuck on the question. It should guide them toward the correct answer without giving it away directly."
-    }
-  },
-  required: ["scenario", "question", "options", "aiAdvice"],
-};
+import { DisasterType, DrillStep, DrillMode, VideoStyle } from '../types';
 
 interface PreviousStepContext {
-    scenario: string;
-    question: string;
-    userAnswer: DrillStepOption;
-    stepsSurvived?: number;
+  scenario: string;
+  question: string;
+  userAnswer: {
+    text: string;
+    isCorrect: boolean;
+    feedback: string;
+  };
+  stepsSurvived?: number;
 }
 
-export const generateDrillScenario = async (disasterType: DisasterType, region: string, mode: DrillMode, previousStepContext?: PreviousStepContext): Promise<DrillStep | null> => {
-  
-  let prompt: string;
-  const studentFocus = "All scenarios and options must be easy for a school student in India to understand.";
+const apiFetch = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const response = await fetch(`/api${path}`, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers || {}),
+    },
+    ...init,
+  });
 
-  if (previousStepContext) {
-    const { scenario, question, userAnswer, stepsSurvived } = previousStepContext;
-    if (mode === 'Survival') {
-       prompt = `This is a continuous SURVIVAL MODE disaster drill about a ${disasterType} in a school in ${region}, India. The user has correctly survived ${stepsSurvived} scenarios so far.
-       The previous situation was: "${scenario}".
-       The user correctly chose the action: "${userAnswer.text}".
-       Now, generate the NEXT logical follow-up scenario in this evolving story. The situation should become slightly more intense or complex, but still be a direct consequence of the previous events. Create a new question and three options (one correct, two incorrect). Ensure the entire scenario is from a student's perspective. ${studentFocus}`;
-    } else { // Standard Mode
-        prompt = `This is a multi-step standard disaster drill for a ${disasterType} in a school in ${region}, India.
-        The previous situation was: "${scenario}".
-        The question asked was: "${question}".
-        The user chose the action: "${userAnswer.text}", which was ${userAnswer.isCorrect ? 'correct' : 'incorrect'}. The feedback provided was: "${userAnswer.feedback}".
-        Now, generate a new, logical follow-up scenario that results from the user's previous action. Create a new multiple-choice question with three distinct options about the immediate correct action. ${studentFocus}`;
-    }
-  } else { // First step of any drill
-    const modeDescription = mode === 'Survival' ? 'This is the START of a continuous SURVIVAL MODE drill.' : 'This is the START of a standard, multi-step drill.';
-    prompt = `Generate a realistic, initial stage disaster scenario for a ${disasterType} in a school located in ${region}, India. ${modeDescription} The scenario should be focused on a student's perspective. Create one multiple-choice question with three options about the immediate correct action. One option must be correct, and the other two must be plausible but incorrect. Provide brief feedback for each option and a concise hint. ${studentFocus}`;
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
   }
 
+  return (await response.json()) as T;
+};
+
+export const generateDrillScenario = async (
+  disasterType: DisasterType,
+  region: string,
+  mode: DrillMode,
+  previousStepContext?: PreviousStepContext
+): Promise<DrillStep | null> => {
   try {
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash",
-      contents: prompt,
-      config: {
-        responseMimeType: "application/json",
-        responseSchema: responseSchema,
-        temperature: 0.8,
-      },
+    return await apiFetch<DrillStep>('/ai/drill-scenario', {
+      method: 'POST',
+      body: JSON.stringify({ disasterType, region, mode, previousStepContext }),
     });
-
-    const jsonText = response.text.trim();
-    const parsedJson = JSON.parse(jsonText);
-
-    // Basic validation to ensure the structure matches DrillStep
-    if (parsedJson.scenario && parsedJson.question && parsedJson.aiAdvice && Array.isArray(parsedJson.options) && parsedJson.options.length === 3) {
-      // Deeper validation for options
-      const allOptionsValid = parsedJson.options.every((opt: any) => 
-        typeof opt.text === 'string' &&
-        typeof opt.isCorrect === 'boolean' &&
-        typeof opt.feedback === 'string'
-      );
-      if (allOptionsValid) {
-        return parsedJson as DrillStep;
-      }
-    }
-    
-    console.error("Parsed JSON does not match the expected DrillStep structure:", parsedJson);
-    return null;
-
   } catch (error) {
-    console.error("Error generating drill scenario:", error);
+    console.error('Error generating drill scenario:', error);
     return null;
   }
 };
 
-export const generateVideoLesson = async (disasterType: DisasterType, videoStyle: VideoStyle): Promise<Blob | null> => {
-    const styleDescription = videoStyle === 'cartoon'
-        ? "an engaging, clear, and friendly 2D animated cartoon style suitable for students. Simple characters, bright colors."
-        : "a realistic, high-fidelity simulation. Cinematic and serious tone, but not overly graphic or scary.";
+export const generateVideoLesson = async (
+  disasterType: DisasterType,
+  videoStyle: VideoStyle
+): Promise<Blob | null> => {
+  try {
+    const response = await fetch('/api/ai/video-lesson', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ disasterType, videoStyle }),
+    });
 
-    const coreContent: Record<DisasterType, string> = {
-        [DisasterType.Earthquake]: `A school classroom starts shaking. Students practice 'Drop, Cover, and Hold On' under their desks. Show an evacuation to an open assembly point. End with a title card: "Earthquake Safety: Drop, Cover, Hold On!"`,
-        [DisasterType.Flood]: `Heavy rain causing water levels to rise around a school. Show students calmly evacuating to a higher floor. A visual of a car being swept away with a "Turn Around, Don't Drown" text overlay. End with a title card: "Flood Preparedness: Stay Safe, Stay Dry."`,
-        [DisasterType.Fire]: `A smoke alarm blares in a school hallway. Students are shown crawling low under smoke. A teacher demonstrates the P.A.S.S. method with a fire extinguisher on a small, controlled fire. Evacuation to an outdoor assembly point. End with a title card: "Fire Emergency: Get Out, Stay Out!"`,
-        [DisasterType.Cyclone]: `Strong winds and rain lashing against school windows. Show students sheltered in a strong interior room away from windows. A tree branch falls outside. Show a post-cyclone scene with downed power lines. End with a title card: "Cyclone Alert: Weather the Storm Safely."`,
-    };
-
-    const prompt = `Generate a short, approximately 30-second educational video about ${disasterType} safety in a school setting in India. The video should be in ${styleDescription}. The scene should show: ${coreContent[disasterType]}. The video should be silent.`;
-
-    try {
-        let operation = await ai.models.generateVideos({
-            model: 'veo-2.0-generate-001',
-            prompt: prompt,
-            config: {
-                numberOfVideos: 1,
-            }
-        });
-
-        while (!operation.done) {
-            await new Promise(resolve => setTimeout(resolve, 10000));
-            operation = await ai.operations.getVideosOperation({ operation: operation });
-        }
-        
-        const downloadLink = operation.response?.generatedVideos?.[0]?.video?.uri;
-        if (downloadLink) {
-            const response = await fetch(`${downloadLink}&key=${process.env.API_KEY}`);
-            if (response.ok) {
-                const videoBlob = await response.blob();
-                return videoBlob;
-            } else {
-                console.error("Failed to download video:", response.statusText);
-                return null;
-            }
-        }
-        return null;
-
-    } catch (error) {
-        console.error("Error generating video lesson:", error);
-        return null;
+    if (!response.ok) {
+      throw new Error(`API request failed: ${response.status} ${response.statusText}`);
     }
+
+    return await response.blob();
+  } catch (error) {
+    console.error('Error generating video lesson:', error);
+    return null;
+  }
 };
 
 export const generateSafetyTips = async (context: string): Promise<string | null> => {
-    let contextDescription: string;
-    switch(context) {
-        case 'home':
-            contextDescription = "on the main home screen of the app. Give general preparedness tips.";
-            break;
-        case 'modules':
-            contextDescription = "looking at the list of available disaster study modules. Give tips about the importance of learning.";
-            break;
-        case 'drills':
-            contextDescription = "in the virtual drills lobby, preparing to start a simulation. Give tips about how to approach a drill.";
-            break;
-        case DisasterType.Earthquake:
-        case DisasterType.Flood:
-        case DisasterType.Fire:
-        case DisasterType.Cyclone:
-            contextDescription = `studying the '${context}' disaster module. Give specific tips for this disaster.`;
-            break;
-        default:
-            contextDescription = "using the app. Give general safety tips.";
-    }
-
-    const prompt = `You are an AI Safety Advisor for the CrisisGuardian app. A user is currently ${contextDescription}. 
-    Generate 3 to 5 concise, actionable safety tips for them. 
-    The tips should be encouraging and easy to understand for a student audience in India. 
-    Format each tip on a new line, starting with a relevant emoji. Do not use markdown like bullet points.
-    Example:
-    📚 Knowledge is power! Regularly review your study modules to keep safety info fresh in your mind.
-    ✅ Check your family's emergency kit every six months to ensure supplies are not expired.`;
-
-    try {
-        const response = await ai.models.generateContent({
-            model: "gemini-2.5-flash",
-            contents: prompt,
-            config: {
-                temperature: 0.7,
-            }
-        });
-        return response.text;
-    } catch (error) {
-        console.error("Error generating safety tips:", error);
-        return null;
-    }
+  try {
+    const payload = await apiFetch<{ tips: string }>('/ai/safety-tips', {
+      method: 'POST',
+      body: JSON.stringify({ context }),
+    });
+    return payload.tips;
+  } catch (error) {
+    console.error('Error generating safety tips:', error);
+    return null;
+  }
 };

--- a/types.ts
+++ b/types.ts
@@ -28,7 +28,7 @@ export interface UnlockedAchievement {
 export interface User {
   name: string;
   email: string;
-  password: string;
+  password?: string;
   phone?: string;
   role: UserRole;
   score: number; // This is now the average score percentage from STANDARD drills

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,8 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
   return {
     server: {
       port: 3000,
@@ -16,10 +15,6 @@ export default defineConfig(({ mode }) => {
       },
     },
     plugins: [react()],
-    define: {
-      'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- Harden backend authentication/session handling and AI proxy routes.
- Move signup OTP verification to secure backend flow.
- Add SMTP-based OTP email delivery for signup and password reset.
- Add Render deployment blueprint and production origin fallback.

## Includes
- Server-side OTP endpoints and token-gated signup.
- SMTP config (SMTP_*) + 
odemailer integration.
- Dependency update: etter-sqlite3 for Node 22 compatibility.
- Docs updates for local run and deployment.

## Validation
- Local build passes (
pm run build).
- Local app start verified (localhost:3000, /api/health).